### PR TITLE
Highlight ^*** as list and not bold

### DIFF
--- a/Creole.tmLanguage
+++ b/Creole.tmLanguage
@@ -425,7 +425,7 @@ Siddley can be contacted at <https://github.com/Siddley/Creole>
 		<dict>
 			<key>begin</key>
 			<string>(?x)
-						(\*\*)(?=\S)									# opening **
+						(?&lt;!\*|^)(\*\*)(?=\S)						# opening **
 						(?=												# zero-width positive lookahead
 							(
 							    &lt;[^&gt;]*+&gt;						# match any HTML tag


### PR DESCRIPTION
There was an issue with *** at the start of line being treated as bold and this fixes it. I'm not sure it's the best fix, but it works for me.